### PR TITLE
Configurable DynamoDB table prefixer

### DIFF
--- a/src/Container/DynamoDbClientFactory.php
+++ b/src/Container/DynamoDbClientFactory.php
@@ -38,10 +38,11 @@ final class DynamoDbClientFactory
     {
         /** @var DynamoDbClient $dynamoDbClient */
         $dynamoDbClient = $container->get(Sdk::class)->createDynamoDb();
+        $config         = $container->get('config')['zfr_aws_utils'] ?? [];
 
-        // If a table name prefixer is registered, we attach it to the handler list
-        if ($container->has(TableNamePrefixer::class)) {
-            $tableNamePrefixer = $container->get(TableNamePrefixer::class);
+        // If a table prefix is configured, we attach a middleware to auto prefix table names
+        if (! empty($config['dynamodb']['table_prefix'])) {
+            $tableNamePrefixer = new TableNamePrefixer($config['dynamodb']['table_prefix']);
 
             $dynamoDbClient->getHandlerList()->prependInit(
                 Middleware::mapCommand($tableNamePrefixer),

--- a/src/DynamoDb/TableNamePrefixer.php
+++ b/src/DynamoDb/TableNamePrefixer.php
@@ -86,7 +86,7 @@ class TableNamePrefixer
         $newRequestItems = [];
 
         foreach ($command['RequestItems'] as $tableName => $requests) {
-            $newTableName                = $this->resolveTableName($tableName);
+            $newTableName                   = $this->resolveTableName($tableName);
             $newRequestItems[$newTableName] = $requests;
         }
 

--- a/test/Container/DynamoDbClientFactoryTest.php
+++ b/test/Container/DynamoDbClientFactoryTest.php
@@ -22,7 +22,6 @@ use Aws\Sdk;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use ZfrAwsUtils\Container\DynamoDbClientFactory;
-use ZfrAwsUtils\DynamoDb\TableNamePrefixer;
 
 /**
  * @author Daniel Gimenes
@@ -31,13 +30,12 @@ final class DynamoDbClientFactoryTest extends TestCase
 {
     public function testCreatesWithTablePrefixer()
     {
-        $sdk           = new Sdk(['region' => 'us-east-1', 'DynamoDb' => ['version' => '2012-08-10']]);
-        $container     = $this->prophesize(ContainerInterface::class);
-        $tablePrefixer = $this->prophesize(TableNamePrefixer::class);
+        $sdk       = new Sdk(['region' => 'us-east-1', 'DynamoDb' => ['version' => '2012-08-10']]);
+        $config    = ['zfr_aws_utils' => ['dynamodb' => ['table_prefix' => 'dev']]];
+        $container = $this->prophesize(ContainerInterface::class);
 
         $container->get(Sdk::class)->shouldBeCalled()->willReturn($sdk);
-        $container->has(TableNamePrefixer::class)->shouldBeCalled()->willReturn(true);
-        $container->get(TableNamePrefixer::class)->shouldBeCalled()->willReturn($tablePrefixer->reveal());
+        $container->get('config')->shouldBeCalled()->willReturn($config);
 
         (new DynamoDbClientFactory())($container->reveal());
     }
@@ -48,8 +46,7 @@ final class DynamoDbClientFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
 
         $container->get(Sdk::class)->shouldBeCalled()->willReturn($sdk);
-        $container->has(TableNamePrefixer::class)->shouldBeCalled()->willReturn(false);
-        $container->get(TableNamePrefixer::class)->shouldNotBeCalled();
+        $container->get('config')->shouldBeCalled()->willReturn([]);
 
         (new DynamoDbClientFactory())($container->reveal());
     }


### PR DESCRIPTION
Actually I found it more easier to configure the table namespace directly in config (and overriding in development mode with development config) instead of creating a custom factory for `TableNamePrefixer`.